### PR TITLE
Remove an error about worker.postMessage

### DIFF
--- a/js/Worker.js
+++ b/js/Worker.js
@@ -555,7 +555,7 @@ onmessage = function (e){
             break;
 
         default:
-            self.postMessage('Unknown command: ' + data.msg);
+            self.postMessage('Unknown command: ' + data.msg, null);
     }
 
 };


### PR DESCRIPTION
worker.postMessage is taking two arguments
worker.postMessage(aMessage, transferList);
https://developer.mozilla.org/fr/docs/Web/API/Worker/postMessage